### PR TITLE
feat: add Dockerfile and update README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,4 @@ RUN  apk add --update \
      && rm /var/cache/apk/*
 RUN npm install
 
-EXPOSE 8201
-
 CMD ["node", "./index.js"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,37 @@ Execute tests.
 
 Web page will communicate with app server to register, etc. agains Mozilla's web push service.
 
+## Run Test (Docker)
+
+### Summary
+
+The test page and app server can be run from a docker container.
+To build your own docker container, follow instructions below.
+To use existing container on dockerhub, do the following:
+
+```
+docker pull firefoxtesteng/autopush-e2e-test
+```
+
+Then follow instructions for Docker Run (below)
+
+
+### Docker Build
+
+```
+docker build -t autopush-e2e-test .
+```
+
+### Docker Run
+
+```
+docker run -p 8201:8201  autopush-e2e-test
+```
+
+Follow instructions for "Run Test" (above)
+
+
+
 
 
 

--- a/index.js
+++ b/index.js
@@ -9,13 +9,14 @@ startServer(8201);
 function startServer(port) {
   var server = new Hapi.Server();
   server.connection({
-    host: process.env.HAPI_SERVER || 'localhost',
+    host: process.env.HAPI_SERVER || '0.0.0.0',
     port: process.env.PORT || port,
     routes: { cors: true }
   });
 
   server.register(Inert, () => {});
 
+  // route to test page - http://localhost:8201
   server.route({
     path: "/{p*}",
     method: "GET",
@@ -28,6 +29,7 @@ function startServer(port) {
     }
   });
 
+  // route to app server (used by test page to talk to autopush) 
   server.route([
     require("./routes/notify")
   ]);
@@ -35,6 +37,5 @@ function startServer(port) {
   server.start(function () {
     console.log('Server running at: %s', server.info.uri);
   });
-
 
 }


### PR DESCRIPTION
r? @chartjes 
I've bundled the source code for:
https://mozilla-services.github.io/autopush-e2e-test (you'll notice it doesn't work anymore)
and the supporting backend app server into this test repo.

Also, you can now run both via Docker either by building it yourself or simply:
```
docker pull firefoxtesteng/autopush-e2e-test
docker run -p 8201:8201 firefoxtesteng/autopush-e2e-test
```
Then open FF browser to:  http://localhost:8201

Closes #2 